### PR TITLE
[FEAT] 상세 검색 Flow 변경 및 검색 전체결과 구현

### DIFF
--- a/Nobar.xcodeproj/project.pbxproj
+++ b/Nobar.xcodeproj/project.pbxproj
@@ -73,7 +73,6 @@
 		3CE598C028748093004AFD05 /* NobarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE598BF28748093004AFD05 /* NobarUITests.swift */; };
 		3CE598C228748093004AFD05 /* NobarUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE598C128748093004AFD05 /* NobarUITestsLaunchTests.swift */; };
 		3CF40A79287E42FC00C44A64 /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF40A78287E42FC00C44A64 /* EndPoint.swift */; };
-		3CF40A79287E42FC00C44A64 /* EndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF40A78287E42FC00C44A64 /* EndPoint.swift */; };
 		46625D497AE08F5753883A05 /* Pods_Nobar.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A933CDF0C185DB2C90BB843F /* Pods_Nobar.framework */; };
 		4D057161287C1AC400CB656A /* SearchResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D057160287C1AC300CB656A /* SearchResultViewController.swift */; };
 		4D057163287CF49A00CB656A /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D057162287CF49900CB656A /* SearchViewController.swift */; };
@@ -572,10 +571,10 @@
 		4D057168287D434700CB656A /* Cell */ = {
 			isa = PBXGroup;
 			children = (
-				4DBA151E288458F00068A487 /* SearchTotalResultCollectionViewCell.swift */,
 				4D057169287D4CDC00CB656A /* RecentCollectionViewCell.swift */,
 				4D05716B287D4D5600CB656A /* RecommendCollectionViewCell.swift */,
 				4D38B5BA28800C8D00CD33ED /* SearchAutoResultCollectionViewCell.swift */,
+				4DBA151E288458F00068A487 /* SearchTotalResultCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -599,19 +598,6 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
-		CE4D87CD1C74D9C83AACE212 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				67EBA53932B4C9CB0EED94B9 /* Pods-Nobar.debug.xcconfig */,
-				4F3374400330F9EB2A23D168 /* Pods-Nobar.release.xcconfig */,
-				7FBA5E93719FAF1B7AA7887E /* Pods-Nobar-NobarUITests.debug.xcconfig */,
-				288561025259F60D2F828E5A /* Pods-Nobar-NobarUITests.release.xcconfig */,
-				D05627346DBEB7E4B065AC2A /* Pods-NobarTests.debug.xcconfig */,
-				9E26C648F5AA54E114C13C50 /* Pods-NobarTests.release.xcconfig */,
-			);
-			path = Pods;
-			sourceTree = "<group>";
-		};
 		6AAD37F1287F21170030646C /* Component */ = {
 			isa = PBXGroup;
 			children = (
@@ -631,6 +617,19 @@
 				6AAD380128800A4C0030646C /* RecommendModel.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		CE4D87CD1C74D9C83AACE212 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				67EBA53932B4C9CB0EED94B9 /* Pods-Nobar.debug.xcconfig */,
+				4F3374400330F9EB2A23D168 /* Pods-Nobar.release.xcconfig */,
+				7FBA5E93719FAF1B7AA7887E /* Pods-Nobar-NobarUITests.debug.xcconfig */,
+				288561025259F60D2F828E5A /* Pods-Nobar-NobarUITests.release.xcconfig */,
+				D05627346DBEB7E4B065AC2A /* Pods-NobarTests.debug.xcconfig */,
+				9E26C648F5AA54E114C13C50 /* Pods-NobarTests.release.xcconfig */,
+			);
+			path = Pods;
 			sourceTree = "<group>";
 		};
 		FE2C118A1DDDEEA41553DA7E /* Frameworks */ = {

--- a/Nobar/Scenes/Search/Component/SearchHeaderView.swift
+++ b/Nobar/Scenes/Search/Component/SearchHeaderView.swift
@@ -12,7 +12,6 @@ import SnapKit
 
 protocol HeaderViewDelegate: AnyObject {
   func didClickOnDeleteButton()
-  func didClickOnTotalResultButton()
 }
 
 final class SearchHeaderView: UICollectionReusableView {
@@ -50,7 +49,6 @@ final class SearchHeaderView: UICollectionReusableView {
     $0.setTitle("전체 보기", for: .normal)
     $0.setTitleColor(Color.gray03.getColor(), for: .normal)
     $0.titleLabel?.font = Pretendard.size13.medium()
-    $0.addTarget(self, action: #selector(didClickOnTotalResultButton(_:)), for: .touchUpInside)
   }
 
   private let topLine = UIView().then {
@@ -146,9 +144,5 @@ extension SearchHeaderView {
   @objc private func didClickOnDeleteButton(_ sender: UIButton) {
     delegate?.didClickOnDeleteButton()
     self.deleteButton.isHidden = true
-  }
-  
-  @objc private func didClickOnTotalResultButton(_ sender: UIButton) {
-    delegate?.didClickOnTotalResultButton()
   }
 }

--- a/Nobar/Scenes/Search/Component/SearchHeaderView.swift
+++ b/Nobar/Scenes/Search/Component/SearchHeaderView.swift
@@ -10,13 +10,10 @@ import UIKit
 import Then
 import SnapKit
 
-protocol HeaderViewDelegate: AnyObject {
-  func didClickOnDeleteButton()
-}
-
 final class SearchHeaderView: UICollectionReusableView {
 
-  weak var delegate: HeaderViewDelegate?
+  var didClickOnDeleteButtonClosure: (() -> Void)?
+  var didClickOnTotalButtonClosure: (() -> Void)?
 
   enum SeachHeaderType {
     case recent
@@ -49,6 +46,7 @@ final class SearchHeaderView: UICollectionReusableView {
     $0.setTitle("전체 보기", for: .normal)
     $0.setTitleColor(Color.gray03.getColor(), for: .normal)
     $0.titleLabel?.font = Pretendard.size13.medium()
+    $0.addTarget(self, action: #selector(didClickOnTotalButton(_:)), for: .touchUpInside)
   }
 
   private let topLine = UIView().then {
@@ -93,6 +91,7 @@ extension SearchHeaderView {
     case .total:
       titleLabel.text = "칵테일 레시피"
       addTotalButton()
+      remakeTitleLayout()
     }
   }
 
@@ -127,7 +126,7 @@ extension SearchHeaderView {
     totalButton.snp.makeConstraints {
       $0.top.equalToSuperview().inset(18)
       $0.bottom.equalToSuperview().inset(15)
-      $0.trailing.equalToSuperview().inset(26)
+      $0.trailing.equalToSuperview()
     }
   }
 
@@ -142,7 +141,11 @@ extension SearchHeaderView {
 // MARK: - Action Functions
 extension SearchHeaderView {
   @objc private func didClickOnDeleteButton(_ sender: UIButton) {
-    delegate?.didClickOnDeleteButton()
+    self.didClickOnDeleteButtonClosure?()
     self.deleteButton.isHidden = true
+  }
+
+  @objc private func didClickOnTotalButton(_ sender: UIButton) {
+    self.didClickOnTotalButtonClosure?()
   }
 }

--- a/Nobar/Scenes/Search/SearchResultViewController.swift
+++ b/Nobar/Scenes/Search/SearchResultViewController.swift
@@ -268,8 +268,9 @@ extension SearchResultViewController: UICollectionViewDataSource {
         headerView.configUI(type: .total)
         headerView.didClickOnTotalButtonClosure = {
           let searchTotalViewController = SearchTotalResultViewController()
-          searchTotalViewController.modalPresentationStyle = .fullScreen
-          self.present(searchTotalViewController, animated: true)
+          let searchNavigationController = UINavigationController(rootViewController: searchTotalViewController)
+          searchNavigationController.modalPresentationStyle = .fullScreen
+          self.present(searchNavigationController, animated: true)
         }
       case .ingredient:
         headerView.configUI(type: .ingredient)

--- a/Nobar/Scenes/Search/SearchResultViewController.swift
+++ b/Nobar/Scenes/Search/SearchResultViewController.swift
@@ -32,7 +32,7 @@ final class SearchResultViewController: BaseViewController {
   }
 
   private lazy var searchTextField = SearchTextField().then {
-    $0.addTarget(self, action: #selector(judgeHasText(_:)), for: .editingChanged)
+    $0.addTarget(self, action: #selector((_:)), for: .editingDidBegin)
   }
 
   private lazy var backButton = UIButton().then {
@@ -123,12 +123,8 @@ extension SearchResultViewController {
 // MARK: - Private Functions
 extension SearchResultViewController {
   private func setTextField() {
-    searchTextField.text = firstKeyword
-    searchTextField.rightViewMode = .always
-    searchTextField.didClickOnClearButtonClosure = {
-      self.searchTextField.text?.removeAll()
-      self.navigationController?.popViewController(animated: false)
-    }
+    searchTextField.resignFirstResponder()
+    searchTextField.text = searchText
   }
   
   private func setRegistration() {

--- a/Nobar/Scenes/Search/SearchResultViewController.swift
+++ b/Nobar/Scenes/Search/SearchResultViewController.swift
@@ -12,27 +12,23 @@ import SnapKit
 
 final class SearchResultViewController: BaseViewController {
 
-  enum Section: Int, CaseIterable {
+  enum ResultSecionType: Int, CaseIterable {
     case cocktail = 0
     case ingredient = 1
   }
 
-  var firstKeyword: String?
-  private var sections: Section?
-  private var dataSource: UICollectionViewDiffableDataSource<Section, String>!
-  private var snapshot: NSDiffableDataSourceSnapshot<Section, String>!
+  var searchText: String?
+  private var resultSectionType: ResultSecionType?
 
-  // TODO: 나중에 서버에서 한꺼번에 리스트로 받아옴
-  private var dummyCocktail: [String] = ["브랜디", "선라이즈피치", "피치크러쉬", "카시스 오렌지", "은비쨩", "칵테일어쩌구", "피치만 나와라", "피치어쩌구", "리큐르", "채원쨩", "피치1", "피치2", "피치3", "피치4"]
-
-  private var dummyIngredient: [String] = ["여긴재료", "주스도있고요", "재료들이", "오렌지주스", "은비쨩", "재료어쩌구", "리큐르", "채원쨩"]
+  // TODO: 이전 뷰에서 필터링 된 재료 리스트 전달 filterIngredient 어쩌구
+  private var dummyIngredient: [String] = ["피피피피", "피치주스도있고요", "재료들이", "오렌지주스", "은비쨩", "재료어쩌구", "리큐르", "채원쨩"]
 
   private let searchView = UIView().then {
     $0.backgroundColor = .white
   }
 
   private lazy var searchTextField = SearchTextField().then {
-    $0.addTarget(self, action: #selector((_:)), for: .editingDidBegin)
+    $0.addTarget(self, action: #selector(beginEditingText(_:)), for: .editingDidBegin)
   }
 
   private lazy var backButton = UIButton().then {
@@ -45,8 +41,8 @@ final class SearchResultViewController: BaseViewController {
     $0.layer.applyShadow(color: .black, alpha: 0.2, x: 1, y: 1, blur: 2, spread: 0)
   }
 
-  private lazy var searchAutoResultCollectionView: UICollectionView = {
-    let layout = createCompositionLayout()
+  private lazy var searchTotalResultCollectionView: UICollectionView = {
+    let layout = createKeywordLayout()
 
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
     collectionView.showsHorizontalScrollIndicator = false
@@ -59,9 +55,8 @@ final class SearchResultViewController: BaseViewController {
     render()
     configUI()
     setTextField()
+    setDelegation()
     setRegistration()
-    setDataSource()
-    performQuery(with: firstKeyword)
   }
 
   override func setupConstraints() {
@@ -78,7 +73,7 @@ final class SearchResultViewController: BaseViewController {
 extension SearchResultViewController {
 
   private func render() {
-    view.addSubviews([searchView, searchAutoResultCollectionView])
+    view.addSubviews([searchView, searchTotalResultCollectionView])
     searchView.addSubviews([backButton, searchTextField, underline])
   }
 
@@ -108,7 +103,7 @@ extension SearchResultViewController {
       $0.height.equalTo(1)
     }
 
-    searchAutoResultCollectionView.snp.makeConstraints {
+    searchTotalResultCollectionView.snp.makeConstraints {
       $0.top.equalTo(underline.snp.bottom)
       $0.leading.trailing.bottom.equalToSuperview()
     }
@@ -126,24 +121,24 @@ extension SearchResultViewController {
     searchTextField.resignFirstResponder()
     searchTextField.text = searchText
   }
+
+  private func setDelegation() {
+    searchTotalResultCollectionView.delegate = self
+    searchTotalResultCollectionView.dataSource = self
+  }
   
   private func setRegistration() {
-    searchAutoResultCollectionView.register(SearchHeaderView.self, forSupplementaryViewOfKind: SearchHeaderView.className, withReuseIdentifier: SearchHeaderView.className)
-    searchAutoResultCollectionView.register(cell: SearchAutoResultCollectionViewCell.self)
+    searchTotalResultCollectionView.register(SearchHeaderView.self, forSupplementaryViewOfKind: SearchHeaderView.className, withReuseIdentifier: SearchHeaderView.className)
+    searchTotalResultCollectionView.register(cell: SearchTotalResultCollectionViewCell.self)
+
+    searchTotalResultCollectionView.register(cell: SearchAutoResultCollectionViewCell.self)
   }
 }
 
 // MARK: - Action Functions
 extension SearchResultViewController {
-  @objc private func judgeHasText(_ sender: UITextField) {
-    if searchTextField.hasText == false {
-      navigationController?.popViewController(animated: false)
-    } else {
-      guard let searchText = searchTextField.text
-      else { return }
-      
-      self.performQuery(with: searchText)
-    }
+  @objc private func beginEditingText(_ sender: UITextField) {
+    self.navigationController?.popViewController(animated: false)
   }
 
   @objc private func didClickOnBackButton(_ sender: UIButton) {
@@ -153,84 +148,138 @@ extension SearchResultViewController {
 
 // MARK: - Compositional Layout
 extension SearchResultViewController {
-  private func createCompositionLayout() -> UICollectionViewCompositionalLayout {
-    let layout = UICollectionViewCompositionalLayout { (sectionNumber, env) -> NSCollectionLayoutSection? in
-      let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                            heightDimension: .fractionalHeight(1))
-      let item = NSCollectionLayoutItem(layoutSize: itemSize)
+  // section 1
+  private func getLayoutTotalResultSection() -> NSCollectionLayoutSection {
+    let columns = 2
+    let spacing = 9.f
 
-      let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                             heightDimension: .absolute(50))
-      let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                          heightDimension: .estimated(75))
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
 
-      let section = NSCollectionLayoutSection(group: group)
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                           heightDimension: .absolute(75))
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: columns)
+    group.interItemSpacing = .fixed(spacing)
 
-      guard let sections = Section(rawValue: sectionNumber) else { return nil }
-      switch sections {
-      case .cocktail:
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 12, trailing: 0)
-      case .ingredient:
-        section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 250, trailing: 0)
+    let section = NSCollectionLayoutSection(group: group)
+    section.interGroupSpacing = spacing
+    section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 26, bottom: 30, trailing: 26)
+
+    let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                            heightDimension: .absolute(50))
+    let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize,
+                                                             elementKind: SearchHeaderView.className,
+                                                             alignment: .topLeading)
+    section.boundarySupplementaryItems = [header]
+
+    return section
+  }
+
+  // section 2
+  private func getLayoutIngredientResultSection() -> NSCollectionLayoutSection {
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                          heightDimension: .fractionalHeight(1))
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                           heightDimension: .absolute(50))
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: 1)
+
+    let section = NSCollectionLayoutSection(group: group)
+
+    let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
+                                            heightDimension: .absolute(50))
+    let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize,
+                                                             elementKind: SearchHeaderView.className,
+                                                             alignment: .topLeading)
+    section.boundarySupplementaryItems = [header]
+    return section
+  }
+
+  // layout
+  private func createKeywordLayout() -> UICollectionViewCompositionalLayout {
+    return UICollectionViewCompositionalLayout { (sectionNumber, env) -> NSCollectionLayoutSection? in
+      switch sectionNumber {
+      case 0: return self.getLayoutTotalResultSection()
+      case 1: return self.getLayoutIngredientResultSection()
+      default: return self.getLayoutIngredientResultSection()
       }
-
-      let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
-                                              heightDimension: .absolute(50))
-      let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: headerSize,
-                                                               elementKind: SearchHeaderView.className,
-                                                               alignment: .topLeading)
-      section.boundarySupplementaryItems = [header]
-      return section
     }
-    return layout
   }
 }
 
-// MARK: - Diffable DataSource
-extension SearchResultViewController {
-  private func setDataSource() {
-    self.dataSource = UICollectionViewDiffableDataSource<Section, String>(collectionView: self.searchAutoResultCollectionView) { (collectionview, indexPath, keyword) -> UICollectionViewCell? in
+// MARK: - CollectionView Delegate functions
+extension SearchResultViewController: UICollectionViewDelegate {
 
-      guard let cell = self.searchAutoResultCollectionView.dequeueReusableCell(withReuseIdentifier: SearchAutoResultCollectionViewCell.className, for: indexPath) as? SearchAutoResultCollectionViewCell else { preconditionFailure() }
+}
 
-      cell.updateResult(keyword)
-      cell.updateAttributedText(self.searchTextField.text ?? "")
+extension SearchResultViewController: UICollectionViewDataSource {
+
+  func numberOfSections(in collectionView: UICollectionView) -> Int {
+    return ResultSecionType.allCases.count
+  }
+
+  func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    guard let sectionType = ResultSecionType(rawValue: section) else { return 1 }
+
+    switch sectionType {
+    case .cocktail:
+      return SearchCocktailModel.dummyCocktailList.count
+    case .ingredient:
+      return dummyIngredient.count
+    }
+
+  }
+
+  func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    guard let sectionType = ResultSecionType(rawValue: indexPath.section) else {
+      return UICollectionViewCell()
+    }
+
+    switch sectionType {
+    case .cocktail:
+      let cell = searchTotalResultCollectionView.dequeueReusableCell(ofType: SearchTotalResultCollectionViewCell.self, at: indexPath)
+
+      cell.updateModel(SearchCocktailModel.dummyCocktailList[indexPath.row])
+      return cell
+    case .ingredient:
+      let cell = searchTotalResultCollectionView.dequeueReusableCell(ofType: SearchAutoResultCollectionViewCell.self, at: indexPath)
+
+      cell.updateResult(dummyIngredient[indexPath.row])
+      cell.updateAttributedText(self.searchText ?? "")
       return cell
     }
-
-    self.dataSource.supplementaryViewProvider = {
-      collectionView, kind, indexPath in
-
-      guard kind == SearchHeaderView.className else { return nil }
-      let view = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: SearchHeaderView.className, for: indexPath) as? SearchHeaderView
-
-      guard let sections = Section(rawValue: indexPath.section) else { return nil }
-      switch sections {
-      case .cocktail:
-        view?.configUI(type: .cocktail)
-      case .ingredient:
-        view?.configUI(type: .ingredient)
-      }
-      return view
-    }
   }
 
-  private func performQuery(with searchText: String?) {
-    guard let searchText = searchText else { return }
+  func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
 
-    let filteredCocktail = self.dummyCocktail.filter { $0.hasPrefix(searchText) }
-    let filteredIngredient = self.dummyIngredient.filter { $0.hasPrefix(searchText) }
+    if kind == SearchHeaderView.className {
+      let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: SearchHeaderView.className, for: indexPath)
 
-    var fiveCocktail = Array(filteredCocktail.prefix(5))
-    let fiveIngredient = Array(filteredIngredient.prefix(5))
+      guard let headerView = headerView as? SearchHeaderView else { return UICollectionReusableView() }
 
-    if fiveCocktail.isEmpty {
-      fiveCocktail.append(" ")
+      guard let sectionType = ResultSecionType(rawValue: indexPath.section) else {
+        return UICollectionViewCell()
+      }
+
+      switch sectionType {
+      case .cocktail:
+        headerView.configUI(type: .total)
+        headerView.didClickOnTotalButtonClosure = {
+          let searchTotalViewController = SearchTotalResultViewController()
+          searchTotalViewController.modalPresentationStyle = .fullScreen
+          self.present(searchTotalViewController, animated: true)
+        }
+      case .ingredient:
+        headerView.configUI(type: .ingredient)
+      }
+
+      return headerView
+    } else {
+      return UICollectionReusableView()
     }
-
-    snapshot = NSDiffableDataSourceSnapshot<Section, String>()
-    snapshot.appendSections([.cocktail, .ingredient])
-    snapshot.appendItems(fiveCocktail, toSection: .cocktail)
-    snapshot.appendItems(fiveIngredient, toSection: .ingredient)
-    dataSource.apply(snapshot, animatingDifferences: true)
   }
 }
+
+

--- a/Nobar/Scenes/Search/SearchTotalResultViewContorller.swift
+++ b/Nobar/Scenes/Search/SearchTotalResultViewContorller.swift
@@ -62,23 +62,16 @@ final class SearchTotalResultViewController: BaseViewController {
 extension SearchTotalResultViewController {
 
   private func render() {
-    view.addSubviews([closeButton, titleLabel, underline, searchTotalResultCollectionView])
+    view.addSubviews([underline, searchTotalResultCollectionView])
   }
 
   private func setLayout() {
     closeButton.snp.makeConstraints {
       $0.width.height.equalTo(42)
-      $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-      $0.leading.equalToSuperview().inset(15)
-    }
-
-    titleLabel.snp.makeConstraints {
-      $0.top.equalToSuperview().inset(55)
-      $0.centerX.equalToSuperview()
     }
 
     underline.snp.makeConstraints {
-      $0.top.equalTo(closeButton.snp.bottom).offset(4)
+      $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
       $0.leading.trailing.equalToSuperview()
       $0.height.equalTo(1)
     }
@@ -91,6 +84,11 @@ extension SearchTotalResultViewController {
 
   private func configUI() {
     view.backgroundColor = Color.white.getColor()
+    navigationItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+    navigationItem.title = "검색 결과"
+    
+    let titleAttribute = [NSAttributedString.Key.font: Pretendard.size16.bold()]
+    self.navigationController?.navigationBar.titleTextAttributes = titleAttribute
   }
 }
 

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -240,7 +240,7 @@ extension SearchViewController: UICollectionViewDataSource {
   }
 
   func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    guard let sectionType = SectionType(rawValue: section) else { return 1 }
+    guard let sectionType = KeywordSectionType(rawValue: section) else { return 1 }
 
     switch sectionType {
     case .recent:
@@ -252,7 +252,7 @@ extension SearchViewController: UICollectionViewDataSource {
   }
 
   func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-    guard let sectionType = SectionType(rawValue: indexPath.section) else {
+    guard let sectionType = KeywordSectionType(rawValue: indexPath.section) else {
       return UICollectionViewCell()
     }
 
@@ -277,7 +277,7 @@ extension SearchViewController: UICollectionViewDataSource {
 
       guard let headerView = headerView as? SearchHeaderView else { return UICollectionReusableView() }
 
-      guard let sectionType = SectionType(rawValue: indexPath.section) else {
+      guard let sectionType = KeywordSectionType(rawValue: indexPath.section) else {
         return UICollectionViewCell()
       }
 

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -170,8 +170,8 @@ extension SearchViewController {
   }
 
   private func initTextField() {
-    searchTextField.text = ""
     searchTextField.rightViewMode = .never
+    searchTextField.becomeFirstResponder()
   }
 
   private func setTextFieldButton() {

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -205,7 +205,13 @@ extension SearchViewController {
   }
 
   @objc private func didClickOnBackButton(_ sender: UIButton) {
-    self.navigationController?.popViewController(animated: true)
+    self.searchTextField.text?.removeAll()
+
+    if view.subviews.contains(searchAutoResultCollectionView) {
+      searchAutoResultCollectionView.removeFromSuperview()
+    } else {
+      self.navigationController?.popViewController(animated: true)
+    }
   }
 }
 
@@ -261,7 +267,7 @@ extension SearchViewController {
     }
   }
 
-  private func createAutoResultLayout() -> UICollectionViewCompositionalLayout {
+  func createAutoResultLayout() -> UICollectionViewCompositionalLayout {
     let layout = UICollectionViewCompositionalLayout { (sectionNumber, env) -> NSCollectionLayoutSection? in
       let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1),
                                             heightDimension: .fractionalHeight(1))
@@ -349,24 +355,18 @@ extension SearchViewController: UICollectionViewDataSource {
       switch sectionType {
       case .recent:
         headerView.configUI(type: .recent)
+        headerView.didClickOnDeleteButtonClosure = {
+          self.dummyKeywords.removeAll()
+          self.searchKeywordCollectionView.reloadSections([0])
+          self.emptyLabel.isHidden = false
+        }
       case .recommend:
         headerView.configUI(type: .recommend)
       }
-      
-      headerView.delegate = self
       return headerView
     } else {
       return UICollectionReusableView()
     }
-  }
-}
-
-// MARK: - HeaderViewDelegate
-extension SearchViewController: HeaderViewDelegate {
-  func didClickOnDeleteButton() {
-    self.dummyKeywords.removeAll()
-    self.searchKeywordCollectionView.reloadSections([0])
-    self.emptyLabel.isHidden = false
   }
 }
 
@@ -424,8 +424,9 @@ extension SearchViewController: UITextFieldDelegate {
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {
     searchTextField.resignFirstResponder()
 
-    let totalResultViewController = SearchTotalResultViewController()
-    self.navigationController?.pushViewController(totalResultViewController, animated: false)
+    let resultViewController = SearchResultViewController()
+    resultViewController.searchText = self.searchTextField.text
+    self.navigationController?.pushViewController(resultViewController, animated: false)
     return true
   }
 }

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -304,7 +304,12 @@ extension SearchViewController: HeaderViewDelegate {
     self.emptyLabel.isHidden = false
   }
 
-  func didClickOnTotalResultButton() {
-    // TODO: 전체 결과 창으로 화면전환
+extension SearchViewController: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    searchTextField.resignFirstResponder()
+
+    let totalResultViewController = SearchTotalResultViewController()
+    self.navigationController?.pushViewController(totalResultViewController, animated: false)
+    return true
   }
 }

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -12,12 +12,18 @@ import SnapKit
 
 final class SearchViewController: BaseViewController {
 
-  enum SectionType: Int {
+  enum KeywordSectionType: Int, CaseIterable {
     case recent = 0
     case recommend = 1
   }
 
-  private var sectionType: SectionType?
+  enum AutoResultSectionType: Int, CaseIterable {
+    case cocktail = 0
+    case ingredient = 1
+  }
+
+  private var keywordSectionType: KeywordSectionType?
+
 
   // TODO: 나중에 서버에서 한꺼번에 리스트로 받아옴
   private var dummyKeywords: [String] = ["브랜디", "선라이즈피치", "피치크러쉬", "카시스 오렌지", "은비쨩", "칵테일어쩌구", "밀푀유나베", "피치어쩌구", "리큐르", "채원쨩??"]

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -83,11 +83,13 @@ extension SearchViewController {
   private func render() {
     view.addSubviews([searchView, searchKeywordCollectionView])
     searchView.addSubviews([backButton, searchTextField, underline])
+    searchKeywordCollectionView.addSubview(emptyLabel)
   }
 
   private func configUI() {
     view.backgroundColor = Color.white.getColor()
     navigationController?.navigationBar.isHidden = true
+    emptyLabel.isHidden = true
   }
 
   private func setLayout() {
@@ -119,6 +121,11 @@ extension SearchViewController {
     searchKeywordCollectionView.snp.makeConstraints {
       $0.top.equalTo(underline.snp.bottom)
       $0.leading.trailing.bottom.equalToSuperview()
+    }
+
+    emptyLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(58)
+      $0.leading.equalToSuperview().inset(126)
     }
   }
 }
@@ -285,6 +292,7 @@ extension SearchViewController: HeaderViewDelegate {
   func didClickOnDeleteButton() {
     self.dummyKeywords.removeAll()
     self.searchKeywordCollectionView.reloadSections([0])
+    self.emptyLabel.isHidden = false
   }
 
   func didClickOnTotalResultButton() {

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -87,8 +87,8 @@ final class SearchViewController: BaseViewController {
   }
 
   override func viewWillAppear(_ animated: Bool) {
-      super.viewWillAppear(animated)
-      initTextField()
+    super.viewWillAppear(animated)
+    initTextField()
   }
 
   override func setupConstraints() {
@@ -173,17 +173,34 @@ extension SearchViewController {
     searchTextField.text = ""
     searchTextField.rightViewMode = .never
   }
+
+  private func setTextFieldButton() {
+    searchTextField.didClickOnClearButtonClosure = {
+      self.searchTextField.text?.removeAll()
+      self.searchAutoResultCollectionView.removeFromSuperview()
+    }
+  }
+
+  private func setAutoResultCollectionView() {
+    view.addSubview(searchAutoResultCollectionView)
+    searchAutoResultCollectionView.snp.makeConstraints {
+      $0.top.equalTo(underline.snp.bottom)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
+  }
 }
 
 // MARK: - Action Functions
 extension SearchViewController {
   @objc private func judgeHasText(_ sender: UITextField) {
     if searchTextField.hasText {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-        let searchResultViewController = SearchResultViewController()
-        searchResultViewController.firstKeyword = self.searchTextField.text
-        self.navigationController?.pushViewController(searchResultViewController, animated: false)
-      }
+      setAutoResultCollectionView()
+      guard let searchText = searchTextField.text else { return }
+
+      self.performQuery(with: searchText)
+
+    } else {
+      searchAutoResultCollectionView.removeFromSuperview()
     }
   }
 

--- a/Nobar/Scenes/Search/SearchViewController.swift
+++ b/Nobar/Scenes/Search/SearchViewController.swift
@@ -19,7 +19,10 @@ final class SearchViewController: BaseViewController {
 
   private var sectionType: SectionType?
 
+  // TODO: 나중에 서버에서 한꺼번에 리스트로 받아옴
   private var dummyKeywords: [String] = ["브랜디", "선라이즈피치", "피치크러쉬", "카시스 오렌지", "은비쨩", "칵테일어쩌구", "밀푀유나베", "피치어쩌구", "리큐르", "채원쨩??"]
+  private var dummyCocktail: [String] = ["브랜디", "선라이즈피치", "피치크러쉬", "카시스 오렌지", "은비쨩", "칵테일어쩌구", "피치만 나와라", "피치어쩌구", "리큐르", "채원쨩", "피치1", "피치2", "피치3", "피치4"]
+  private var dummyIngredient: [String] = ["피피피피", "피치주스도있고요", "재료들이", "오렌지주스", "은비쨩", "재료어쩌구", "리큐르", "채원쨩"]
 
   private let searchView = UIView().then {
     $0.backgroundColor = Color.white.getColor()


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
- closed #35 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
1. 기존에 다른 뷰컨으로 분리했었던 검색 뷰를 하나로 합치고 컬렉션뷰 2개로 나눴어요
2. 전체 검색 결과 뷰도 완성했어요 ! 
3. 플로우를 자연스럽게 여러 기능들을 넣었어요 ! 
4. 이상한거 있으면 리뷰 달아주세요 

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->

### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
검색 뷰 남은 작업 
- 자동완성 화면전환 
- 최근 검색어 화면전환
- 추천 검색어 화면전환
- 최근 검색어 전체삭제 버튼 안없어지는 오류 (리로드 때문에)
- 최근 검색어 로컬 db
- 추천검색어 날짜 라벨 : 오늘 날짜로 

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
||![Simulator Screen Recording - iPhone 11 - 2022-07-18 at 16 06 44](https://user-images.githubusercontent.com/81313960/179460239-0b9974ed-c84a-4dae-a945-a7fdc9b025bc.gif)|
