### PR TITLE
[FEAT] 홈뷰 레이아웃 수정

### DIFF
--- a/Nobar/Scenes/Main/Component/HomeHeaderView.swift
+++ b/Nobar/Scenes/Main/Component/HomeHeaderView.swift
@@ -18,11 +18,6 @@ final class HomeHeaderView: UICollectionReusableView {
     case recommend
   }
   
-  private var subTitleLabel = UILabel().then {
-    $0.textColor = Color.gray03.getColor()
-    $0.font = Pretendard.size12.medium()
-  }
-  
   private var titleLabel = UILabel().then {
     $0.textColor = Color.navy01.getColor()
     $0.font = Pretendard.size20.black()
@@ -49,31 +44,22 @@ final class HomeHeaderView: UICollectionReusableView {
 extension HomeHeaderView {
   
   private func render() {
-    addSubviews([
-      subTitleLabel,
-      titleLabel
-    ])
-    subTitleLabel.snp.makeConstraints {
-      $0.top.equalToSuperview().offset(12)
-      $0.leading.equalToSuperview().offset(31)
-    }
+    addSubview(titleLabel)
+  
     titleLabel.snp.makeConstraints {
-      $0.top.equalTo(subTitleLabel.snp.bottom).offset(2)
-      $0.leading.equalTo(subTitleLabel.snp.leading)
+      $0.centerY.equalToSuperview()
+      $0.leading.equalToSuperview().offset(31)
     }
   }
   
   func configUI(type: HomeHeaderType) {
     switch type {
     case .archive:
-      subTitleLabel.text = "소제목소제목소제목"
-      titleLabel.text = "노바님이 나중에 만들 레시피"
+      titleLabel.text = "나중에 만들 레시피"
       self.addSeeAllButton()
     case .guide:
-      subTitleLabel.text = "소제목소제목소제목"
       titleLabel.text = "칵테일 가이드"
     case .recommend:
-      subTitleLabel.text = "소제목소제목소제목"
       titleLabel.text = "바가 필요 없는 레시피"
       
     }
@@ -82,8 +68,7 @@ extension HomeHeaderView {
   private func addSeeAllButton() {
     addSubview(seeAllButton)
     seeAllButton.snp.makeConstraints {
-      $0.top.equalToSuperview().offset(34)
-      $0.bottom.equalToSuperview()
+      $0.top.equalToSuperview().offset(19)
       $0.trailing.equalToSuperview().offset(-26)
     }
   }

--- a/Nobar/Scenes/Main/Component/RecommendCVC.swift
+++ b/Nobar/Scenes/Main/Component/RecommendCVC.swift
@@ -14,9 +14,18 @@ final class RecommendCVC: UICollectionViewCell {
   
   private let titleLabel = UILabel().then {
     $0.textColor = Color.white.getColor()
-    $0.font = Pretendard.size17.bold()
+    $0.font = Pretendard.size14.semibold()
     $0.lineBreakMode = .byWordWrapping
     $0.numberOfLines = 2
+  }
+  private let subTitleLabel = UILabel().then {
+    $0.textColor = Color.skyblue02.getColor()
+    $0.font = Pretendard.size10.medium()
+    $0.text = "자세히 보기"
+  }
+  private let thumbImage = UIImageView().then {
+    $0.image = ImageFactory.dummy1
+    $0.layer.cornerRadius = 12
   }
 
   override init(frame: CGRect) {
@@ -41,12 +50,22 @@ final class RecommendCVC: UICollectionViewCell {
 extension RecommendCVC {
   
   private func render() {
-    addSubview(titleLabel)
+    addSubviews([titleLabel,subTitleLabel,thumbImage])
     titleLabel.snp.makeConstraints {
       $0.leading.equalToSuperview().offset(20)
-      $0.trailing.equalToSuperview().inset(80)
-      $0.centerY.equalToSuperview()
+      $0.centerY.equalToSuperview().offset(-7)
+      $0.width.equalTo(150)
+     
     }
+    subTitleLabel.snp.makeConstraints{
+      $0.top.equalTo(titleLabel.snp.bottom)
+      $0.leading.equalTo(titleLabel)
+    }
+    thumbImage.snp.makeConstraints{
+      $0.top.bottom.trailing.equalToSuperview()
+      $0.width.equalTo(80)
+    }
+                 
   }
 
   private func configUI() {
@@ -56,6 +75,7 @@ extension RecommendCVC {
   func setData(with data: RecommendModel){
     titleLabel.text = data.title
     backgroundColor = UIColor(hex: data.color)
+    thumbImage.image = UIImage(named: data.imageName)
   }
   
 }

--- a/Nobar/Scenes/Main/MainViewController.swift
+++ b/Nobar/Scenes/Main/MainViewController.swift
@@ -75,6 +75,7 @@ extension MainViewController {
   }
   
   private func setLayout() {
+    grayLine.isHidden = true
     navigationController?.navigationBar.isHidden = true
     
     logoView.snp.makeConstraints {
@@ -95,7 +96,7 @@ extension MainViewController {
       $0.height.equalTo(1)
     }
     homeCollectionView.snp.makeConstraints {
-      $0.top.equalTo(logoView.snp.bottom)
+      $0.top.equalTo(grayLine.snp.bottom)
       $0.leading.trailing.bottom.equalToSuperview()
     }
   }
@@ -228,9 +229,19 @@ extension MainViewController {
   }
 }
 
+
+extension MainViewController: UIScrollViewDelegate{
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    if scrollView.contentOffset.y > 0{
+      grayLine.isHidden = false
+    }else{
+      grayLine.isHidden = true
+    }
+  }
+}
 // MARK: - CollectionViewDelegate
 extension MainViewController: UICollectionViewDelegate{
-  
+
 }
 
 // MARK: - CollectionViewDataSource

--- a/Nobar/Scenes/Main/MainViewController.swift
+++ b/Nobar/Scenes/Main/MainViewController.swift
@@ -24,7 +24,9 @@ final class MainViewController: BaseViewController {
   private let logoImageView = UIImageView().then {
     $0.image = ImageFactory.logo
   }
-  
+  private let grayLine = UIView().then{
+    $0.backgroundColor = Color.gray02.getColor()
+  }
   private lazy var homeCollectionView: UICollectionView = {
     let layout = getLayout()
     layout.configuration.interSectionSpacing = 0
@@ -35,8 +37,8 @@ final class MainViewController: BaseViewController {
     collectionView.showsHorizontalScrollIndicator = false
     collectionView.showsVerticalScrollIndicator = false
     collectionView.register(
-      CocktailCVC.self,
-      forCellWithReuseIdentifier: CocktailCVC.identifier)
+      SearchTotalResultCollectionViewCell.self,
+      forCellWithReuseIdentifier: SearchTotalResultCollectionViewCell.identifier)
     return collectionView
   }()
   
@@ -67,7 +69,7 @@ extension MainViewController {
   
   private func render() {
     view.addSubviews(
-      [logoView,
+      [logoView,grayLine,
        homeCollectionView])
     logoView.addSubview(logoImageView)
   }
@@ -87,7 +89,11 @@ extension MainViewController {
       $0.width.equalTo(120)
       $0.height.equalTo(24)
     }
-    
+    grayLine.snp.makeConstraints{
+      $0.top.equalTo(logoView.snp.bottom)
+      $0.leading.trailing.equalToSuperview()
+      $0.height.equalTo(1)
+    }
     homeCollectionView.snp.makeConstraints {
       $0.top.equalTo(logoView.snp.bottom)
       $0.leading.trailing.bottom.equalToSuperview()
@@ -103,8 +109,8 @@ extension MainViewController {
     homeCollectionView.register(HomeHeaderView.self,
                                 forSupplementaryViewOfKind: "HomeHeaderView",
                                 withReuseIdentifier: "HomeHeaderView")
-    homeCollectionView.register(CocktailCVC.self,
-                                forCellWithReuseIdentifier: "CocktailCVC")
+    homeCollectionView.register(SearchTotalResultCollectionViewCell.self,
+                                forCellWithReuseIdentifier: "SearchTotalResultCollectionViewCell")
     homeCollectionView.register(GuideCVC.self,
                                 forCellWithReuseIdentifier: "GuideCVC")
     homeCollectionView.register(RecommendCVC.self,
@@ -117,33 +123,23 @@ extension MainViewController {
 
 extension MainViewController {
   private func getArchiveSectionLayout() -> NSCollectionLayoutSection {
-    //        let itemInset: CGFloat = 2.5
     
-    let itemSize = NSCollectionLayoutSize(
-      widthDimension: .fractionalWidth(0.5),
-      heightDimension: .fractionalHeight(1)
-    )
+    let columns = 2
+    let spacing = CGFloat(9)
+
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                          heightDimension: .estimated(75))
     let item = NSCollectionLayoutItem(layoutSize: itemSize)
-    item.contentInsets = NSDirectionalEdgeInsets(
-      top: 4.5,
-      leading: 4.5,
-      bottom: 4.5,
-      trailing: 4.5)
-    
-    let groupSize = NSCollectionLayoutSize(
-      widthDimension: .fractionalWidth(1.0),
-      heightDimension: .estimated(120.0)
-    )
-    let group = NSCollectionLayoutGroup.horizontal(
-      layoutSize: groupSize,
-      subitems: [item])
-    
+
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                           heightDimension: .absolute(75))
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: columns)
+    group.interItemSpacing = .fixed(spacing)
+
     var section = NSCollectionLayoutSection(group: group)
-    section.contentInsets = NSDirectionalEdgeInsets(
-      top: 12,
-      leading: 26,
-      bottom: 12,
-      trailing: 26)
+    section.interGroupSpacing = spacing
+    section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 26, bottom: 30, trailing: 26)
+    
     
     section = self.addHeaderView(section: section)
     
@@ -168,10 +164,10 @@ extension MainViewController {
     var section = NSCollectionLayoutSection(group: group)
     section.interGroupSpacing = 12
     section.contentInsets = NSDirectionalEdgeInsets(
-      top: 12,
+      top: 0,
       leading: 26,
       bottom: 12,
-      trailing: 26)
+      trailing: 32)
     section.orthogonalScrollingBehavior = .continuous
     
     section = self.addHeaderView(section: section)
@@ -221,7 +217,7 @@ extension MainViewController {
   private func addHeaderView(section: NSCollectionLayoutSection) -> NSCollectionLayoutSection{
     let headerSize = NSCollectionLayoutSize(
       widthDimension: .fractionalWidth(1.0),
-      heightDimension: .absolute(50))
+      heightDimension: .absolute(47))
     let headerSupplementary = NSCollectionLayoutBoundarySupplementaryItem(
       layoutSize: headerSize,
       elementKind: "HomeHeaderView",
@@ -267,9 +263,9 @@ extension MainViewController: UICollectionViewDataSource{
     
     switch sectionType {
     case .archive:
-      let cell = homeCollectionView.dequeueReusableCell(ofType: CocktailCVC.self,
+      let cell = homeCollectionView.dequeueReusableCell(ofType: SearchTotalResultCollectionViewCell.self,
                                                         at: indexPath)
-      cell.setData(with: CocktailModel.dummyCocktailList[indexPath.row])
+      cell.updateModel(SearchCocktailModel.dummyCocktailList[indexPath.row])
       return cell
     case .guide:
       let cell = homeCollectionView.dequeueReusableCell(ofType: GuideCVC.self,

--- a/Nobar/Scenes/Main/Model/RecommendModel.swift
+++ b/Nobar/Scenes/Main/Model/RecommendModel.swift
@@ -10,16 +10,17 @@ import Foundation
 struct RecommendModel {
   var title: String
   var color: String
+  var imageName: String
 
 }
 
 extension RecommendModel {
   static let dummyRecommendList: [RecommendModel] = [
-    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#0A2588"),
-    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#0E30AA"),
-    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#07207A"),
-    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#1E43C7"),
-    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#0029BC")
+    RecommendModel(title: "12시 귀가를 보장하는 논알콜 칵테일, 신데렐라", color: "#0A2588",imageName: "dummy1"),
+    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#0E30AA",imageName: "dummy2"),
+    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#07207A",imageName: "dummy1"),
+    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#1E43C7",imageName: "dummy2"),
+    RecommendModel(title: "블루하와이 마셔봤니? 편의점에서 간편하게 재료 겟!", color: "#0029BC",imageName: "dummy1")
   ]
 }
 


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
closed #61 

### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
- 홈뷰 나중레시피 셀과 추천 레시피 셀을 변경하였습니다.
- 이미지는 지금은 찌그러져있지만 나중에 받을때 맞는 크기 이미지로 받아서 들어갈 예정입니다.
- 홈뷰 스크롤시 로고 상단 회색선이 보이도록 구현하였습니다.

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
컬렉션뷰를 UIScrollDelegate 채택해서 사용하는 거를 처음 해봤지 머에요 .
굉장히 편하고 좋네요 .. 
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|홈뷰|![Screen_Recording_2022-07-21_at_6_42_44_PM_AdobeExpress](https://user-images.githubusercontent.com/51031771/180184340-72690e71-8543-428f-8f23-d1fd74d20ead.gif)|

