### PR TITLE
[FEAT] 나중에볼 레시피 전체보기 뷰 구현

### DIFF
--- a/Nobar.xcodeproj/project.pbxproj
+++ b/Nobar.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		6AAD38002880086C0030646C /* RecommendCVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD37FF2880086A0030646C /* RecommendCVC.swift */; };
 		6AAD380228800A4D0030646C /* RecommendModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD380128800A4C0030646C /* RecommendModel.swift */; };
 		6AAD3804288012910030646C /* UIColor+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AAD3803288012910030646C /* UIColor+Extension.swift */; };
+		6ABD2A0E288972C100FBC72B /* LaterRecipeAllViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6ABD2A0D288972C100FBC72B /* LaterRecipeAllViewController.swift */; };
 		6CD81E2E4E59CD8EA6F6C81A /* Pods_Nobar_NobarUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFEFAACA04DDB3B90D4FE900 /* Pods_Nobar_NobarUITests.framework */; };
 /* End PBXBuildFile section */
 
@@ -254,6 +255,7 @@
 		6AAD37FF2880086A0030646C /* RecommendCVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendCVC.swift; sourceTree = "<group>"; };
 		6AAD380128800A4C0030646C /* RecommendModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecommendModel.swift; sourceTree = "<group>"; };
 		6AAD3803288012910030646C /* UIColor+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Extension.swift"; sourceTree = "<group>"; };
+		6ABD2A0D288972C100FBC72B /* LaterRecipeAllViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaterRecipeAllViewController.swift; sourceTree = "<group>"; };
 		7FBA5E93719FAF1B7AA7887E /* Pods-Nobar-NobarUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Nobar-NobarUITests.debug.xcconfig"; path = "Target Support Files/Pods-Nobar-NobarUITests/Pods-Nobar-NobarUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		9E26C648F5AA54E114C13C50 /* Pods-NobarTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NobarTests.release.xcconfig"; path = "Target Support Files/Pods-NobarTests/Pods-NobarTests.release.xcconfig"; sourceTree = "<group>"; };
 		A933CDF0C185DB2C90BB843F /* Pods_Nobar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Nobar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -412,6 +414,7 @@
 				6AAD37F1287F21170030646C /* Component */,
 				3CE598A428748092004AFD05 /* Main.storyboard */,
 				3CE598A228748092004AFD05 /* MainViewController.swift */,
+				6ABD2A0D288972C100FBC72B /* LaterRecipeAllViewController.swift */,
 			);
 			path = Main;
 			sourceTree = "<group>";
@@ -667,6 +670,16 @@
 			path = SignUp;
 			sourceTree = "<group>";
 		};
+		4D8D03042888E5610023288D /* Setting */ = {
+			isa = PBXGroup;
+			children = (
+				4D8D03052888E58B0023288D /* SettingViewController.swift */,
+				4D8D03072888EE990023288D /* SettingHeaderView.swift */,
+				4D8D03092888F24F0023288D /* SettingDetailView.swift */,
+			);
+			path = Setting;
+			sourceTree = "<group>";
+		};
 		4DF28D18288942B10019C930 /* Splash */ = {
 			isa = PBXGroup;
 			children = (
@@ -681,16 +694,6 @@
 				4DF28D2028894F810019C930 /* 111529-rocket.json */,
 			);
 			path = Lottie;
-			sourceTree = "<group>";
-		};
-		4D8D03042888E5610023288D /* Setting */ = {
-			isa = PBXGroup;
-			children = (
-				4D8D03052888E58B0023288D /* SettingViewController.swift */,
-				4D8D03072888EE990023288D /* SettingHeaderView.swift */,
-				4D8D03092888F24F0023288D /* SettingDetailView.swift */,
-			);
-			path = Setting;
 			sourceTree = "<group>";
 		};
 		6AAD37F1287F21170030646C /* Component */ = {
@@ -986,6 +989,7 @@
 				4D057161287C1AC400CB656A /* SearchResultViewController.swift in Sources */,
 				3CD437152877EC780044AE04 /* MyPageViewController.swift in Sources */,
 				6AAD37EA287C7FBA0030646C /* PanDirectionGesture.swift in Sources */,
+				6ABD2A0E288972C100FBC72B /* LaterRecipeAllViewController.swift in Sources */,
 				4DBA151F288458F00068A487 /* SearchTotalResultCollectionViewCell.swift in Sources */,
 				3CA17C1128789A2200E67B27 /* Color.swift in Sources */,
 				3CDE20112875F23E00680B8C /* Identifiable.swift in Sources */,

--- a/Nobar/Scenes/Main/Component/HomeHeaderView.swift
+++ b/Nobar/Scenes/Main/Component/HomeHeaderView.swift
@@ -12,6 +12,8 @@ import SnapKit
 
 final class HomeHeaderView: UICollectionReusableView {
   
+  var didClickOnSeeAllButtonClosure: (() -> Void)?
+  
   enum HomeHeaderType {
     case archive
     case guide
@@ -23,10 +25,11 @@ final class HomeHeaderView: UICollectionReusableView {
     $0.font = Pretendard.size20.black()
   }
   
-  private var seeAllButton = UIButton().then {
+  private lazy var seeAllButton = UIButton().then {
     $0.setTitle("전체 보기", for: .normal)
     $0.setTitleColor(Color.gray03.getColor(), for: .normal)
     $0.titleLabel?.font = Pretendard.size13.medium()
+    $0.addTarget(self, action: #selector(didClickOnSeeAlllButton(_:)), for: .touchUpInside)
   }
   
   override init(frame: CGRect) {
@@ -73,5 +76,11 @@ extension HomeHeaderView {
     }
   }
   
+}
+
+extension HomeHeaderView {
+  @objc private func didClickOnSeeAlllButton(_ sender: UIButton) {
+    self.didClickOnSeeAllButtonClosure?()
+  }
 }
 

--- a/Nobar/Scenes/Main/LaterRecipeAllViewController.swift
+++ b/Nobar/Scenes/Main/LaterRecipeAllViewController.swift
@@ -1,0 +1,144 @@
+//
+//  LaterRecipeAllViewController.swift
+//  Nobar
+//
+//  Created by 이유진 on 2022/07/21.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+final class LaterRecipeAllViewController: BaseViewController {
+
+  enum Section: Int, CaseIterable {
+    case recipe
+  }
+
+  private var recipeDataSource: UICollectionViewDiffableDataSource<Section, SearchCocktailModel>!
+  private var recipeSnapshot: NSDiffableDataSourceSnapshot<Section, SearchCocktailModel>!
+
+  private lazy var closeButton = UIButton().then {
+    $0.setImage(ImageFactory.btnCancel, for: .normal)
+    $0.addTarget(self, action: #selector(didClickOnCloseButton(_:)), for: .touchUpInside)
+  }
+
+  private let titleLabel = UILabel().then {
+    $0.text = "나중에 볼 레시피"
+    $0.font = Pretendard.size16.bold()
+    $0.textColor = Color.black.getColor()
+  }
+
+  private let underline = UIView().then {
+    $0.backgroundColor = Color.gray02.getColor()
+  }
+
+  // 전체 collecitonView
+  private lazy var laterRecipeCollectionView: UICollectionView = {
+    let layout = createTotalListLayout()
+
+    let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
+    collectionView.showsHorizontalScrollIndicator = false
+    collectionView.showsVerticalScrollIndicator = true
+    collectionView.register(cell: SearchTotalResultCollectionViewCell.self)
+    return collectionView
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    render()
+    configUI()
+    setDataSource()
+  }
+
+  override func setupConstraints() {
+    super.setupConstraints()
+    setLayout()
+  }
+}
+
+// MARK: - UI & Layout
+extension LaterRecipeAllViewController {
+
+  private func render() {
+    view.addSubviews([underline, laterRecipeCollectionView])
+  }
+
+  private func setLayout() {
+    closeButton.snp.makeConstraints {
+      $0.width.height.equalTo(42)
+    }
+
+    underline.snp.makeConstraints {
+      $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+      $0.leading.trailing.equalToSuperview()
+      $0.height.equalTo(1)
+    }
+
+    laterRecipeCollectionView.snp.makeConstraints {
+      $0.top.equalTo(underline.snp.bottom).offset(14)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
+  }
+
+  private func configUI() {
+    view.backgroundColor = Color.white.getColor()
+    navigationItem.leftBarButtonItem = UIBarButtonItem(customView: closeButton)
+    
+    let titleAttribute = [NSAttributedString.Key.font: Pretendard.size16.bold(), NSAttributedString.Key.foregroundColor: Color.black.getColor()]
+    self.navigationController?.navigationBar.titleTextAttributes = titleAttribute
+
+    navigationItem.title = "나중에 볼 레시피"
+  }
+}
+
+// MARK: - Action Functions
+extension LaterRecipeAllViewController {
+  @objc private func didClickOnCloseButton(_ sender: UIButton) {
+    self.dismiss(animated: true)
+  }
+}
+
+// MARK: - Compositional Layout
+extension LaterRecipeAllViewController {
+  private func createTotalListLayout() -> UICollectionViewCompositionalLayout {
+    return UICollectionViewCompositionalLayout { (sectionNumber, env) -> NSCollectionLayoutSection? in
+      let columns = 2
+      let spacing = CGFloat(9)
+
+      let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                            heightDimension: .estimated(75))
+      let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+      let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                             heightDimension: .absolute(75))
+      let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitem: item, count: columns)
+      group.interItemSpacing = .fixed(spacing)
+
+      let section = NSCollectionLayoutSection(group: group)
+      section.interGroupSpacing = spacing
+      section.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 26, bottom: 30, trailing: 26)
+      
+      return section
+    }
+  }
+}
+
+// MARK: - Diffable DataSource
+extension LaterRecipeAllViewController {
+  private func setDataSource() {
+    self.recipeDataSource = UICollectionViewDiffableDataSource<Section, SearchCocktailModel>(collectionView: self.laterRecipeCollectionView) { (collectionview, indexPath, keyword) -> UICollectionViewCell? in
+
+      guard let cell = self.laterRecipeCollectionView.dequeueReusableCell(withReuseIdentifier: SearchTotalResultCollectionViewCell.className, for: indexPath) as? SearchTotalResultCollectionViewCell else { preconditionFailure() }
+
+      cell.updateModel(keyword)
+      return cell
+    }
+
+    recipeSnapshot = NSDiffableDataSourceSnapshot<Section, SearchCocktailModel>()
+    recipeSnapshot.appendSections([.recipe])
+    recipeSnapshot.appendItems(SearchCocktailModel.dummyCocktailList, toSection: .recipe)
+    recipeDataSource.apply(recipeSnapshot, animatingDifferences: true)
+  }
+}

--- a/Nobar/Scenes/Main/MainViewController.swift
+++ b/Nobar/Scenes/Main/MainViewController.swift
@@ -309,6 +309,12 @@ extension MainViewController: UICollectionViewDataSource{
       switch sectionType {
       case .archive:
         headerView.configUI(type: .archive)
+        headerView.didClickOnSeeAllButtonClosure = {
+          let laterRecipeAllViewController = LaterRecipeAllViewController()
+          let laterRecipehNavigationController = UINavigationController(rootViewController: laterRecipeAllViewController)
+          laterRecipehNavigationController.modalPresentationStyle = .fullScreen
+          self.present(laterRecipehNavigationController, animated: true)
+        }
       case .guide:
         headerView.configUI(type: .guide)
       case .recommend:


### PR DESCRIPTION
### 👀 관련 이슈
<!-- 관련 이슈를 적어주세요 -->
closed #67 
### ✨ 작업한 내용
<!-- 작업한 내용을 적어주세요 -->
나중에 볼레시피 전체 보기 화면을 구현했습니다.
수연이가 만든 뷰 재사용 쇽삭입니다 ~^^ 
변수만 조금 바꿨어여

### 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->
여기 pr엔 제가짠 코드가 없어여 ..
### 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->

### 📷 스크린샷 또는 GIF
|기능|스크린샷|
|:--:|:--:|
|나중에볼레시피 전체보기기|![Screen_Recording_2022-07-21_at_9_30_48_PM_AdobeExpress](https://user-images.githubusercontent.com/51031771/180214464-8e4d7758-2e1f-44ad-a72d-6ae8a54f6e94.gif)|

